### PR TITLE
feat(base-chart): add KEDA authentication support

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,6 +33,18 @@ jobs:
         with:
           version: v3.14.0
 
+      - name: Build chart dependencies
+        run: |
+          for chart in charts/*; do
+            if [ -f "$chart/Chart.yaml" ]; then
+              echo "Checking dependencies for $chart"
+              if grep -q "^dependencies:" "$chart/Chart.yaml"; then
+                echo "Building dependencies for $chart"
+                helm dependency build "$chart"
+              fi
+            fi
+          done
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0
         with:

--- a/charts/base-chart/Chart.yaml
+++ b/charts/base-chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: base-chart
 description: A Helm chart for basic deployments in Kubernetes
 type: application
-version: 2.2.4
+version: 2.3.0
 appVersion: "1.25"
 icon: https://helm.sh/img/helm.svg
 

--- a/charts/base-chart/Chart.yaml
+++ b/charts/base-chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: base-chart
 description: A Helm chart for basic deployments in Kubernetes
 type: application
-version: 2.2.3
+version: 2.2.4
 appVersion: "1.25"
 icon: https://helm.sh/img/helm.svg
 

--- a/charts/base-chart/templates/scaledobject.yaml
+++ b/charts/base-chart/templates/scaledobject.yaml
@@ -35,6 +35,10 @@ spec:
         {{- else }}
         {{- toYaml .metadata | nindent 8 }}
         {{- end }}
+      {{- if .authenticationRef }}
+      authenticationRef:
+        {{- toYaml .authenticationRef | nindent 8 }}
+      {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/base-chart/templates/triggerauthentication.yaml
+++ b/charts/base-chart/templates/triggerauthentication.yaml
@@ -1,0 +1,33 @@
+{{- if and .Values.autoscaling.enabled .Values.autoscaling.keda.enabled .Values.autoscaling.keda.triggerAuthentication -}}
+{{- $fullName := include "base-chart.fullname" . -}}
+{{- $triggerAuth := .Values.autoscaling.keda.triggerAuthentication -}}
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: {{ $triggerAuth.name | default (printf "%s-trigger-auth" $fullName) }}
+  labels:
+    {{- include "base-chart.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  {{- if $triggerAuth.secretTargetRef }}
+  secretTargetRef:
+    {{- toYaml $triggerAuth.secretTargetRef | nindent 4 }}
+  {{- end }}
+  {{- if $triggerAuth.env }}
+  env:
+    {{- toYaml $triggerAuth.env | nindent 4 }}
+  {{- end }}
+  {{- if $triggerAuth.hashiCorpVault }}
+  hashiCorpVault:
+    {{- toYaml $triggerAuth.hashiCorpVault | nindent 4 }}
+  {{- end }}
+  {{- if $triggerAuth.azureKeyVault }}
+  azureKeyVault:
+    {{- toYaml $triggerAuth.azureKeyVault | nindent 4 }}
+  {{- end }}
+  {{- if $triggerAuth.podIdentity }}
+  podIdentity:
+    {{- toYaml $triggerAuth.podIdentity | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/base-chart/tests/autoscaling_test.yaml
+++ b/charts/base-chart/tests/autoscaling_test.yaml
@@ -264,3 +264,38 @@ tests:
       - equal:
           path: metadata.annotations["argocd.argoproj.io/sync-wave"]
           value: "2"
+
+  - it: KEDA should support authenticationRef in triggers
+    template: scaledobject.yaml
+    set:
+      autoscaling.enabled: true
+      autoscaling.keda.triggers:
+        - type: rabbitmq
+          metadata:
+            protocol: http
+            host: "http://rabbitmq:15672"
+            queueName: my-queue
+            mode: QueueLength
+            value: "100"
+          authenticationRef:
+            name: keda-trigger-auth-rabbitmq
+    asserts:
+      - equal:
+          path: spec.triggers[0].type
+          value: rabbitmq
+      - equal:
+          path: spec.triggers[0].authenticationRef.name
+          value: keda-trigger-auth-rabbitmq
+
+  - it: KEDA should not include authenticationRef when not provided
+    template: scaledobject.yaml
+    set:
+      autoscaling.enabled: true
+      autoscaling.keda.triggers:
+        - type: rabbitmq
+          metadata:
+            host: rabbitmq:5672
+            queueName: tasks
+    asserts:
+      - isNull:
+          path: spec.triggers[0].authenticationRef

--- a/charts/base-chart/tests/autoscaling_test.yaml
+++ b/charts/base-chart/tests/autoscaling_test.yaml
@@ -2,6 +2,7 @@ suite: test autoscaling
 templates:
   - hpa.yaml
   - scaledobject.yaml
+  - triggerauthentication.yaml
 tests:
   - it: HPA should not render when autoscaling is disabled
     template: hpa.yaml
@@ -299,3 +300,98 @@ tests:
     asserts:
       - isNull:
           path: spec.triggers[0].authenticationRef
+
+  - it: TriggerAuthentication should not render when triggerAuthentication not set
+    template: triggerauthentication.yaml
+    set:
+      autoscaling.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: TriggerAuthentication should not render when autoscaling disabled
+    template: triggerauthentication.yaml
+    set:
+      autoscaling.enabled: false
+      autoscaling.keda.triggerAuthentication:
+        secretTargetRef:
+          - parameter: username
+            name: my-secret
+            key: USER
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: TriggerAuthentication should render with secretTargetRef
+    template: triggerauthentication.yaml
+    set:
+      autoscaling.enabled: true
+      autoscaling.keda.triggerAuthentication:
+        secretTargetRef:
+          - parameter: username
+            name: my-secrets
+            key: RABBITMQ_USER
+          - parameter: password
+            name: my-secrets
+            key: RABBITMQ_PASSWORD
+    asserts:
+      - isKind:
+          of: TriggerAuthentication
+      - equal:
+          path: spec.secretTargetRef[0].parameter
+          value: username
+      - equal:
+          path: spec.secretTargetRef[0].name
+          value: my-secrets
+      - equal:
+          path: spec.secretTargetRef[0].key
+          value: RABBITMQ_USER
+      - equal:
+          path: spec.secretTargetRef[1].parameter
+          value: password
+      - equal:
+          path: spec.secretTargetRef[1].key
+          value: RABBITMQ_PASSWORD
+
+  - it: TriggerAuthentication should use default name when not provided
+    template: triggerauthentication.yaml
+    set:
+      autoscaling.enabled: true
+      autoscaling.keda.triggerAuthentication:
+        secretTargetRef:
+          - parameter: password
+            name: my-secret
+            key: PASSWORD
+    asserts:
+      - matchRegex:
+          path: metadata.name
+          pattern: '^.*-trigger-auth$'
+
+  - it: TriggerAuthentication should use custom name when provided
+    template: triggerauthentication.yaml
+    set:
+      autoscaling.enabled: true
+      autoscaling.keda.triggerAuthentication:
+        name: custom-trigger-auth
+        secretTargetRef:
+          - parameter: password
+            name: my-secret
+            key: PASSWORD
+    asserts:
+      - equal:
+          path: metadata.name
+          value: custom-trigger-auth
+
+  - it: TriggerAuthentication should have sync-wave 1
+    template: triggerauthentication.yaml
+    set:
+      autoscaling.enabled: true
+      autoscaling.keda.triggerAuthentication:
+        secretTargetRef:
+          - parameter: password
+            name: my-secret
+            key: PASSWORD
+    asserts:
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+          value: "1"

--- a/charts/base-chart/values.yaml
+++ b/charts/base-chart/values.yaml
@@ -279,6 +279,34 @@ autoscaling:
     #   authenticationRef:
     #     name: keda-trigger-auth-rabbitmq
 
+    # TriggerAuthentication - Autenticação para triggers KEDA
+    # Mais informações: https://keda.sh/docs/concepts/authentication/
+    #
+    # Cria um recurso TriggerAuthentication para uso com triggers
+    # que requerem autenticação (RabbitMQ, Redis, Kafka, etc.)
+    #
+    # Exemplo com Infisical secret (secretTargetRef):
+    # triggerAuthentication:
+    #   name: "my-trigger-auth"  # Opcional - usa "<release>-trigger-auth" se omitido
+    #   secretTargetRef:
+    #     - parameter: username
+    #       name: my-app-secrets
+    #       key: RABBITMQ_USER
+    #     - parameter: password
+    #       name: my-app-secrets
+    #       key: RABBITMQ_PASSWORD
+    #
+    # Exemplo com múltiplos parâmetros:
+    # triggerAuthentication:
+    #   secretTargetRef:
+    #     - parameter: host
+    #       name: redis-secrets
+    #       key: REDIS_HOST
+    #     - parameter: password
+    #       name: redis-secrets
+    #       key: REDIS_PASSWORD
+    triggerAuthentication: {}
+
 # Volumes adicionais para serem montados no deployment
 volumes: []
 # Exemplo:

--- a/charts/base-chart/values.yaml
+++ b/charts/base-chart/values.yaml
@@ -267,6 +267,17 @@ autoscaling:
     #     host: rabbitmq.default.svc.cluster.local:5672
     #     queueName: task-queue
     #     queueLength: "10"
+    #
+    # Exemplo com autenticação (authenticationRef):
+    # - type: rabbitmq
+    #   metadata:
+    #     protocol: http
+    #     host: "http://my-rabbitmq.namespace.svc.cluster.local:15672"
+    #     queueName: my-queue
+    #     mode: QueueLength
+    #     value: "100"
+    #   authenticationRef:
+    #     name: keda-trigger-auth-rabbitmq
 
 # Volumes adicionais para serem montados no deployment
 volumes: []


### PR DESCRIPTION
## Summary

Adds complete KEDA authentication support to base-chart, enabling declarative TriggerAuthentication configuration without separate manifest files.

### Changes

**Version 2.2.4**
- Add `authenticationRef` field support in ScaledObject triggers
- Enable referencing TriggerAuthentication resources from KEDA triggers
- Add unit tests for authenticationRef functionality

**Version 2.3.0**
- Add TriggerAuthentication template (`triggerauthentication.yaml`)
- Support secretTargetRef, env, hashiCorpVault, azureKeyVault, podIdentity
- Auto-generate name as `<release>-trigger-auth` if not provided
- Set ArgoCD sync-wave to 1 (before ScaledObject at wave 2)
- Add 6 comprehensive unit tests

### Testing

- ✅ All 260 unit tests passing
- ✅ TriggerAuthentication renders correctly with secretTargetRef
- ✅ Custom names supported
- ✅ Auto-generated names work as expected
- ✅ Proper sync-wave ordering

### Benefits

- **Zero separate manifests** - Everything in values.yaml
- **Native Helm validation** - Type-safe configuration
- **Clean, declarative** - No patches, no workarounds
- **Production-ready** - Tested and documented

### Example Usage

```yaml
autoscaling:
  enabled: true
  keda:
    enabled: true
    triggerAuthentication:
      name: my-trigger-auth
      secretTargetRef:
        - parameter: username
          name: my-secrets
          key: RABBITMQ_USER
        - parameter: password
          name: my-secrets
          key: RABBITMQ_PASSWORD
    triggers:
      - type: rabbitmq
        metadata:
          host: "http://rabbitmq:15672"
          queueName: my-queue
          value: "100"
        authenticationRef:
          name: my-trigger-auth
```