### PR TITLE
feat(sequin): remove bitnami/common dependency, bump to 0.3.0

### DIFF
--- a/charts/sequin/Chart.lock
+++ b/charts/sequin/Chart.lock
@@ -1,9 +1,6 @@
 dependencies:
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.40.0
 - name: valkey
   repository: oci://registry-1.docker.io/cloudpirates
   version: 0.17.0
-digest: sha256:fcc3c9089a7676461942b3bf282962764a356dd6cd430db39be63fc574a03e08
-generated: "2026-06-25T12:00:20.299720458-03:00"
+digest: sha256:1f7d9d24c701bc49eada4081fa973b6d848585d383b4d47a491f8dd4a420cecd
+generated: "2026-06-26T13:33:12.442941643-03:00"

--- a/charts/sequin/Chart.yaml
+++ b/charts/sequin/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sequin
 description: Helm chart for Sequin with external PostgreSQL (Cloud SQL) and Valkey cache
-version: 0.2.3
+version: 0.3.0
 type: application
 maintainers:
   - name: Carter Pedersen
@@ -11,19 +11,8 @@ maintainers:
     email: alexey@zhokhov.com
     url: https://github.com/donbeave
 dependencies:
-  # bitnami/common is a template-only helper library (no runtime pods or containers).
-  # It provides Go template functions used throughout this chart (common.names.fullname,
-  # common.labels.standard, common.tplvalues.render, etc.). Removing it would require
-  # rewriting all chart templates — out of scope for INFRAVPIA-114. This is the sole
-  # remaining Bitnami reference; it carries no operational risk since it is never deployed.
-  - name: common
-    repository: oci://registry-1.docker.io/bitnamicharts
-    tags:
-      - bitnami-common
-    version: 2.x.x
   # Valkey sub-chart — same source used by base-chart (oci://registry-1.docker.io/cloudpirates).
-  # Deployed in standalone mode. Creates service "sequin-valkey" in the sequin namespace.
-  # Sequin connects via externalRedis.host="sequin-valkey" (redis.enabled=false path).
+  # Deployed in standalone mode. Sequin connects via externalRedis.host (redis.enabled=false path).
   - name: valkey
     version: "0.17.0"
     repository: "oci://registry-1.docker.io/cloudpirates"

--- a/charts/sequin/templates/_helpers.tpl
+++ b/charts/sequin/templates/_helpers.tpl
@@ -1,70 +1,293 @@
 {{/*
-Return the proper Sequin image name
+Expand the chart name.
+*/}}
+{{- define "sequin.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name. Truncated at 63 chars (DNS spec).
+*/}}
+{{- define "sequin.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Chart name and version label value.
+*/}}
+{{- define "sequin.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels. Accepts dict with "customLabels" (map or YAML string) and "context" (root scope).
+Mirrors common.labels.standard: customLabels are merged first (higher priority); standard labels
+fill in any missing keys. Extra keys from customLabels are preserved.
+*/}}
+{{- define "sequin.labels" -}}
+{{- $ctx := .context -}}
+{{- $default := dict
+    "app.kubernetes.io/name"       (include "sequin.fullname" $ctx)
+    "helm.sh/chart"                (include "sequin.chart" $ctx)
+    "app.kubernetes.io/instance"   $ctx.Release.Name
+    "app.kubernetes.io/managed-by" $ctx.Release.Service -}}
+{{- if $ctx.Chart.AppVersion -}}
+{{- $_ := set $default "app.kubernetes.io/version" ($ctx.Chart.AppVersion | replace "+" "_") -}}
+{{- end -}}
+{{- $customMap := dict -}}
+{{- with .customLabels -}}
+{{- if typeIs "string" . -}}
+{{- $customMap = (. | fromYaml) -}}
+{{- else -}}
+{{- $customMap = . -}}
+{{- end -}}
+{{- end -}}
+{{- merge $customMap $default | toYaml -}}
+{{- end }}
+
+{{/*
+Selector labels. Accepts dict with "customLabels" (map or YAML string) and "context" (root scope).
+Mirrors common.labels.matchLabels: only picks app.kubernetes.io/name and app.kubernetes.io/instance
+from customLabels (allowing user override of those two keys), then merges with context defaults.
+No arbitrary custom labels are added to matchLabels (immutable field — would break rolling updates).
+*/}}
+{{- define "sequin.selectorLabels" -}}
+{{- $ctx := .context -}}
+{{- $default := dict
+    "app.kubernetes.io/name"     (include "sequin.fullname" $ctx)
+    "app.kubernetes.io/instance" $ctx.Release.Name -}}
+{{- $customMap := dict -}}
+{{- with .customLabels -}}
+{{- if typeIs "string" . -}}
+{{- $customMap = (. | fromYaml) -}}
+{{- else -}}
+{{- $customMap = . -}}
+{{- end -}}
+{{- end -}}
+{{- $picked := pick $customMap "app.kubernetes.io/name" "app.kubernetes.io/instance" -}}
+{{- merge $picked $default | toYaml -}}
+{{- end }}
+
+{{/*
+Render a value as a template. Accepts dict with "value" and "context".
+Replaces common.tplvalues.render.
+*/}}
+{{- define "sequin.tplrender" -}}
+{{- $value := .value -}}
+{{- if typeIs "string" $value }}
+{{- tpl $value .context }}
+{{- else }}
+{{- tpl (toYaml $value) .context }}
+{{- end }}
+{{- end }}
+
+{{/*
+Merge a list of values into a single map and render as YAML.
+Accepts dict with "values" (list of maps) and "context".
+Replaces common.tplvalues.merge.
+*/}}
+{{- define "sequin.mergeValues" -}}
+{{- $merged := dict -}}
+{{- range .values -}}
+{{- if . -}}
+{{- $merged = merge $merged . -}}
+{{- end -}}
+{{- end -}}
+{{- toYaml $merged -}}
+{{- end }}
+
+{{/*
+Render a securityContext, stripping the "enabled" field (Helm values convention, not K8s API).
+Accepts dict with "secContext" (map) and "context".
+Replaces common.compatibility.renderSecurityContext (Openshift shim removed — plain K8s only).
+*/}}
+{{- define "sequin.renderSecurityContext" -}}
+{{- omit .secContext "enabled" | toYaml -}}
+{{- end }}
+
+{{/*
+Pod affinity/anti-affinity preset block.
+Accepts dict with "type" ("soft"|"hard"|""), "customLabels", "context".
+Replaces common.affinities.pods.
+*/}}
+{{- define "sequin.affinities.pods" -}}
+{{- $type := default "" .type -}}
+{{- if eq $type "soft" -}}
+preferredDuringSchedulingIgnoredDuringExecution:
+  - podAffinityTerm:
+      labelSelector:
+        matchLabels: {{- include "sequin.selectorLabels" (dict "customLabels" .customLabels "context" .context) | nindent 10 }}
+      topologyKey: kubernetes.io/hostname
+    weight: 1
+{{- else if eq $type "hard" -}}
+requiredDuringSchedulingIgnoredDuringExecution:
+  - labelSelector:
+      matchLabels: {{- include "sequin.selectorLabels" (dict "customLabels" .customLabels "context" .context) | nindent 8 }}
+    topologyKey: kubernetes.io/hostname
+{{- end -}}
+{{- end }}
+
+{{/*
+Node affinity preset block.
+Accepts dict with "type" ("soft"|"hard"|""), "key", "values".
+Replaces common.affinities.nodes.
+*/}}
+{{- define "sequin.affinities.nodes" -}}
+{{- $type := default "" .type -}}
+{{- if and $type .key .values -}}
+{{- if eq $type "soft" -}}
+preferredDuringSchedulingIgnoredDuringExecution:
+  - preference:
+      matchExpressions:
+        - key: {{ .key }}
+          operator: In
+          values: {{- toYaml .values | nindent 12 }}
+    weight: 1
+{{- else if eq $type "hard" -}}
+requiredDuringSchedulingIgnoredDuringExecution:
+  nodeSelectorTerms:
+    - matchExpressions:
+        - key: {{ .key }}
+          operator: In
+          values: {{- toYaml .values | nindent 12 }}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Return resource requests/limits for a given preset tier.
+Local copy of bitnami/common.resources.preset — removes the bitnami/common dependency
+while preserving identical behavior. Default tier in use: "small".
+*/}}
+{{- define "sequin.resources.preset" -}}
+{{- $presets := dict
+  "nano"    (dict "requests" (dict "cpu" "100m" "memory" "128Mi"  "ephemeral-storage" "50Mi")
+                  "limits"   (dict "cpu" "150m" "memory" "192Mi"  "ephemeral-storage" "2Gi"))
+  "micro"   (dict "requests" (dict "cpu" "250m" "memory" "256Mi"  "ephemeral-storage" "50Mi")
+                  "limits"   (dict "cpu" "375m" "memory" "384Mi"  "ephemeral-storage" "2Gi"))
+  "small"   (dict "requests" (dict "cpu" "500m" "memory" "512Mi"  "ephemeral-storage" "50Mi")
+                  "limits"   (dict "cpu" "750m" "memory" "768Mi"  "ephemeral-storage" "2Gi"))
+  "medium"  (dict "requests" (dict "cpu" "500m" "memory" "1024Mi" "ephemeral-storage" "50Mi")
+                  "limits"   (dict "cpu" "750m" "memory" "1536Mi" "ephemeral-storage" "2Gi"))
+  "large"   (dict "requests" (dict "cpu" "1.0"  "memory" "2048Mi" "ephemeral-storage" "50Mi")
+                  "limits"   (dict "cpu" "1.5"  "memory" "3072Mi" "ephemeral-storage" "2Gi"))
+  "xlarge"  (dict "requests" (dict "cpu" "1.0"  "memory" "3072Mi" "ephemeral-storage" "50Mi")
+                  "limits"   (dict "cpu" "3.0"  "memory" "6144Mi" "ephemeral-storage" "2Gi"))
+  "2xlarge" (dict "requests" (dict "cpu" "1.0"  "memory" "3072Mi" "ephemeral-storage" "50Mi")
+                  "limits"   (dict "cpu" "6.0"  "memory" "12288Mi" "ephemeral-storage" "2Gi"))
+}}
+{{- if hasKey $presets .type -}}
+{{- index $presets .type | toYaml -}}
+{{- else -}}
+{{- printf "ERROR: Preset key '%s' invalid. Allowed values are %s" .type (join "," (keys $presets)) | fail -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Return the proper Sequin image name (registry/repository:tag or repository:tag).
+Replaces common.images.image.
 */}}
 {{- define "sequin.image" -}}
-{{ include "common.images.image" (dict "imageRoot" .Values.image "global" .Values.global) }}
+{{- $registry := coalesce .Values.global.imageRegistry .Values.image.registry "" -}}
+{{- $repository := .Values.image.repository -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- $digest := .Values.image.digest | default "" -}}
+{{- if $digest -}}
+{{- if $registry -}}
+{{- printf "%s/%s@%s" $registry $repository $digest -}}
+{{- else -}}
+{{- printf "%s@%s" $repository $digest -}}
 {{- end -}}
+{{- else -}}
+{{- if $registry -}}
+{{- printf "%s/%s:%s" $registry $repository $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repository $tag -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
 
 {{/*
-Return the proper Docker Image Registry Secret Names
+Return imagePullSecrets block (merges global and local).
+Replaces common.images.pullSecrets.
 */}}
 {{- define "sequin.imagePullSecrets" -}}
-{{ include "common.images.pullSecrets" (dict "images" (list .Values.image) "global" .Values.global) }}
-{{- end -}}
+{{- $pullSecrets := concat (.Values.global.imagePullSecrets | default list) (.Values.image.pullSecrets | default list) -}}
+{{- if $pullSecrets }}
+imagePullSecrets:
+{{- range $pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
+{{- end }}
 
 {{/*
-Get the Sequin configuration ConfigMap
+Get the Sequin configuration ConfigMap name.
 */}}
 {{- define "sequin.configmapName" -}}
 {{- if .Values.existingConfigmap -}}
     {{- tpl .Values.existingConfigmap . -}}
 {{- else }}
-    {{- include "common.names.fullname" . -}}
+    {{- include "sequin.fullname" . -}}
 {{- end -}}
 {{- end -}}
 
 {{/*
-Create the name of the service account to use
+Create the name of the service account to use.
 */}}
 {{- define "sequin.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create -}}
-    {{ default (include "common.names.fullname" .) .Values.serviceAccount.name }}
+    {{ default (include "sequin.fullname" .) .Values.serviceAccount.name }}
 {{- else -}}
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
 
 {{/*
-Sequin credential secret name
+Sequin credential secret name.
 */}}
 {{- define "sequin.secretName" -}}
-{{- coalesce .Values.existingSecret (include "common.names.fullname" .) -}}
+{{- coalesce .Values.existingSecret (include "sequin.fullname" .) -}}
 {{- end -}}
 
 {{/*
-Create a default fully qualified app name for PostgreSQL
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+Create a default fully qualified app name for PostgreSQL.
+Replaces common.names.dependency.fullname for the postgresql sub-chart.
+PostgreSQL is always disabled in our config (externalDatabase path is used instead).
 */}}
 {{- define "sequin.postgresql.fullname" -}}
-{{- include "common.names.dependency.fullname" (dict "chartName" "postgresql" "chartValues" .Values.postgresql "context" $) -}}
+{{- if .Values.postgresql.fullnameOverride -}}
+{{- .Values.postgresql.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-postgresql" (include "sequin.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 
 {{/*
-Return the Database Hostname
+Return the Database Hostname.
 */}}
 {{- define "sequin.database.host" -}}
 {{- ternary (include "sequin.postgresql.fullname" .) .Values.externalDatabase.host .Values.postgresql.enabled -}}
 {{- end -}}
 
 {{/*
-Return the Database Port
+Return the Database Port.
 */}}
 {{- define "sequin.database.port" -}}
 {{- ternary "5432" .Values.externalDatabase.port .Values.postgresql.enabled -}}
 {{- end -}}
 
 {{/*
-Return the Database Name
+Return the Database Name.
 */}}
 {{- define "sequin.database.name" -}}
 {{- if .Values.postgresql.enabled }}
@@ -83,7 +306,7 @@ Return the Database Name
 {{- end -}}
 
 {{/*
-Return the Database User
+Return the Database User.
 */}}
 {{- define "sequin.database.username" -}}
 {{- if .Values.postgresql.enabled }}
@@ -102,7 +325,7 @@ Return the Database User
 {{- end -}}
 
 {{/*
-Return the Database Secret Name
+Return the Database Secret Name.
 */}}
 {{- define "sequin.database.secretName" -}}
 {{- if .Values.postgresql.enabled }}
@@ -120,20 +343,25 @@ Return the Database Secret Name
         {{- default (include "sequin.postgresql.fullname" .) (tpl .Values.postgresql.auth.existingSecret $) -}}
     {{- end -}}
 {{- else -}}
-    {{- default (printf "%s-externaldb" (include "common.names.fullname" .)) (tpl .Values.externalDatabase.existingSecret $) -}}
+    {{- default (printf "%s-externaldb" (include "sequin.fullname" .)) (tpl .Values.externalDatabase.existingSecret $) -}}
 {{- end -}}
 {{- end -}}
 
 {{/*
-Get the Redis&reg; fullname
+Get the Redis&reg; fullname.
+Replaces common.names.dependency.fullname for the redis sub-chart.
+Redis is always disabled in our config (externalRedis path is used instead).
 */}}
 {{- define "sequin.redis.fullname" -}}
-{{- include "common.names.dependency.fullname" (dict "chartName" "redis" "chartValues" .Values.redis "context" $) -}}
+{{- if .Values.redis.fullnameOverride -}}
+{{- .Values.redis.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-redis" (include "sequin.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 
 {{/*
 Create a default fully qualified redis name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "sequin.redis.host" -}}
 {{- if .Values.redis.enabled -}}
@@ -144,7 +372,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
-Get the Redis&reg; port
+Get the Redis&reg; port.
 */}}
 {{- define "sequin.redis.port" -}}
 {{- if .Values.redis.enabled -}}
@@ -167,6 +395,6 @@ Get the Redis&reg; credentials secret.
 {{- else if .Values.externalRedis.existingSecret -}}
     {{- print (tpl .Values.externalRedis.existingSecret .) -}}
 {{- else -}}
-    {{- printf "%s-externalredis" (include "common.names.fullname" .) -}}
+    {{- printf "%s-externalredis" (include "sequin.fullname" .) -}}
 {{- end -}}
 {{- end -}}

--- a/charts/sequin/templates/configmap.yaml
+++ b/charts/sequin/templates/configmap.yaml
@@ -2,13 +2,13 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "common.names.fullname" . }}
-  namespace: {{ include "common.names.namespace" . | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  name: {{ template "sequin.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "sequin.labels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "sequin.tplrender" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 data:
   config.yaml: |-
-    {{- include "common.tplvalues.render" (dict "value" .Values.configuration "context" $) | nindent 4 }}
+    {{- include "sequin.tplrender" (dict "value" .Values.configuration "context" $) | nindent 4 }}
 {{- end }}

--- a/charts/sequin/templates/deployment.yaml
+++ b/charts/sequin/templates/deployment.yaml
@@ -1,20 +1,20 @@
-apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
+apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "common.names.fullname" . }}
-  namespace: {{ include "common.names.namespace" . | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  name: {{ include "sequin.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "sequin.labels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "sequin.tplrender" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   {{- if .Values.updateStrategy }}
   strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
+  {{- $podLabels := include "sequin.mergeValues" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
-    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
+    matchLabels: {{- include "sequin.selectorLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
   template:
     metadata:
       annotations:
@@ -22,29 +22,29 @@ spec:
         checksum/configuration: {{ include (print $.Template.BasePath "/configmap.yaml") $ | sha256sum }}
         {{- end }}
         {{- if .Values.podAnnotations }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
+        {{- include "sequin.tplrender" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
         {{- end }}
-      labels: {{- include "common.labels.standard" ( dict "customLabels" $podLabels "context" $ ) | nindent 8 }}
+      labels: {{- include "sequin.labels" ( dict "customLabels" $podLabels "context" $ ) | nindent 8 }}
     spec:
       serviceAccountName: {{ include "sequin.serviceAccountName" . }}
       {{- include "sequin.imagePullSecrets" . | nindent 6 }}
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- if .Values.hostAliases }}
-      hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
+      hostAliases: {{- include "sequin.tplrender" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.affinity }}
-      affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.affinity "context" $) | nindent 8 }}
+      affinity: {{- include "sequin.tplrender" ( dict "value" .Values.affinity "context" $) | nindent 8 }}
       {{- else }}
       affinity:
-        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAffinityPreset "customLabels" $podLabels "context" $) | nindent 10 }}
-        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAntiAffinityPreset "customLabels" $podLabels "context" $) | nindent 10 }}
-        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.nodeAffinityPreset.type "key" .Values.nodeAffinityPreset.key "values" .Values.nodeAffinityPreset.values) | nindent 10 }}
+        podAffinity: {{- include "sequin.affinities.pods" (dict "type" .Values.podAffinityPreset "customLabels" $podLabels "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "sequin.affinities.pods" (dict "type" .Values.podAntiAffinityPreset "customLabels" $podLabels "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "sequin.affinities.nodes" (dict "type" .Values.nodeAffinityPreset.type "key" .Values.nodeAffinityPreset.key "values" .Values.nodeAffinityPreset.values) | nindent 10 }}
       {{- end }}
       {{- if .Values.nodeSelector }}
-      nodeSelector: {{- include "common.tplvalues.render" ( dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
+      nodeSelector: {{- include "sequin.tplrender" ( dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.tolerations }}
-      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.tolerations "context" .) | nindent 8 }}
+      tolerations: {{- include "sequin.tplrender" (dict "value" .Values.tolerations "context" .) | nindent 8 }}
       {{- end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
@@ -53,28 +53,28 @@ spec:
       schedulerName: {{ .Values.schedulerName | quote }}
       {{- end }}
       {{- if .Values.podSecurityContext.enabled }}
-      securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.podSecurityContext "context" $) | nindent 8 }}
+      securityContext: {{- include "sequin.renderSecurityContext" (dict "secContext" .Values.podSecurityContext "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.initContainers }}
       initContainers:
-        {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
+        {{- include "sequin.tplrender" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
       {{- end }}
       containers:
         - name: sequin
           image: {{ include "sequin.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.containerSecurityContext.enabled }}
-          securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.containerSecurityContext "context" $) | nindent 12 }}
+          securityContext: {{- include "sequin.renderSecurityContext" (dict "secContext" .Values.containerSecurityContext "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.diagnosticMode.enabled }}
-          command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
+          command: {{- include "sequin.tplrender" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
           {{- else if .Values.command }}
-          command: {{- include "common.tplvalues.render" (dict "value" .Values.command "context" $) | nindent 12 }}
+          command: {{- include "sequin.tplrender" (dict "value" .Values.command "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.diagnosticMode.enabled }}
-          args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
+          args: {{- include "sequin.tplrender" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
           {{- else if .Values.args }}
-          args: {{- include "common.tplvalues.render" (dict "value" .Values.args "context" $) | nindent 12 }}
+          args: {{- include "sequin.tplrender" (dict "value" .Values.args "context" $) | nindent 12 }}
           {{- end }}
           env:
             - name: PG_HOSTNAME
@@ -120,54 +120,54 @@ spec:
               value: /sequin/etc/config.yaml
             {{- end }}
             {{- if .Values.extraEnvVars }}
-            {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+            {{- include "sequin.tplrender" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
           envFrom:
             {{- if .Values.extraEnvVarsCM }}
             - configMapRef:
-                name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsCM "context" $) }}
+                name: {{ include "sequin.tplrender" (dict "value" .Values.extraEnvVarsCM "context" $) }}
             {{- end }}
             {{- if .Values.extraEnvVarsSecret }}
             - secretRef:
-                name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsSecret "context" $) }}
+                name: {{ include "sequin.tplrender" (dict "value" .Values.extraEnvVarsSecret "context" $) }}
             {{- end }}
           {{- if .Values.resources }}
           resources: {{- toYaml .Values.resources | nindent 12 }}
           {{- else if ne .Values.resourcesPreset "none" }}
-          resources: {{- include "common.resources.preset" (dict "type" .Values.resourcesPreset) | nindent 12 }}
+          resources: {{- include "sequin.resources.preset" (dict "type" .Values.resourcesPreset) | nindent 12 }}
           {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.containerPorts.http }}
             {{- if .Values.extraContainerPorts }}
-            {{- include "common.tplvalues.render" (dict "value" .Values.extraContainerPorts "context" $) | nindent 12 }}
+            {{- include "sequin.tplrender" (dict "value" .Values.extraContainerPorts "context" $) | nindent 12 }}
             {{- end }}
           {{- if not .Values.diagnosticMode.enabled }}
           {{- if .Values.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
+          livenessProbe: {{- include "sequin.tplrender" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.livenessProbe.enabled }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.livenessProbe "enabled") "context" $) | nindent 12 }}
+          livenessProbe: {{- include "sequin.tplrender" (dict "value" (omit .Values.livenessProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
               port: http
           {{- end }}
           {{- if .Values.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
+          readinessProbe: {{- include "sequin.tplrender" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
           {{- else if .Values.readinessProbe.enabled }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.readinessProbe "enabled") "context" $) | nindent 12 }}
+          readinessProbe: {{- include "sequin.tplrender" (dict "value" (omit .Values.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /
               port: http
           {{- end }}
           {{- if .Values.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customStartupProbe "context" $) | nindent 12 }}
+          startupProbe: {{- include "sequin.tplrender" (dict "value" .Values.customStartupProbe "context" $) | nindent 12 }}
           {{- else if .Values.startupProbe.enabled }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.startupProbe "enabled") "context" $) | nindent 12 }}
+          startupProbe: {{- include "sequin.tplrender" (dict "value" (omit .Values.startupProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
               port: http
           {{- end }}
           {{- end }}
           {{- if .Values.lifecycleHooks }}
-          lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" $) | nindent 12 }}
+          lifecycle: {{- include "sequin.tplrender" (dict "value" .Values.lifecycleHooks "context" $) | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: empty-dir
@@ -179,10 +179,10 @@ spec:
               subPath: config.yaml
           {{- end }}
           {{- if .Values.extraVolumeMounts }}
-          {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- include "sequin.tplrender" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
         {{- if .Values.sidecars }}
-        {{- include "common.tplvalues.render" ( dict "value" .Values.sidecars "context" $) | nindent 8 }}
+        {{- include "sequin.tplrender" ( dict "value" .Values.sidecars "context" $) | nindent 8 }}
         {{- end }}
       volumes:
         - name: empty-dir
@@ -193,5 +193,5 @@ spec:
             name: {{ template "sequin.configmapName" $ }}
         {{- end }}
         {{- if .Values.extraVolumes }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
+        {{- include "sequin.tplrender" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
         {{- end }}

--- a/charts/sequin/templates/ingress.yaml
+++ b/charts/sequin/templates/ingress.yaml
@@ -1,14 +1,14 @@
 {{- if .Values.ingress.enabled }}
-apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "common.names.fullname" . }}
-  namespace: {{ include "common.names.namespace" . | quote }}
-  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingress.labels .Values.commonLabels ) "context" . ) }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
+  name: {{ include "sequin.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  {{- $labels := include "sequin.mergeValues" ( dict "values" ( list .Values.ingress.labels .Values.commonLabels ) "context" . ) }}
+  labels: {{- include "sequin.labels" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
   {{- if or .Values.ingress.annotations .Values.commonAnnotations }}
-  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingress.annotations .Values.commonAnnotations ) "context" . ) }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+  {{- $annotations := include "sequin.mergeValues" ( dict "values" ( list .Values.ingress.annotations .Values.commonAnnotations ) "context" . ) }}
+  annotations: {{- include "sequin.tplrender" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
   {{- if .Values.ingress.ingressClassName }}
@@ -16,7 +16,7 @@ spec:
   {{- end }}
   rules:
     {{- if .Values.ingress.hostname }}
-    - host: {{ include "common.tplvalues.render" ( dict "value" .Values.ingress.hostname "context" $ ) }}
+    - host: {{ include "sequin.tplrender" ( dict "value" .Values.ingress.hostname "context" $ ) }}
       http:
         paths:
           {{- if .Values.ingress.extraPaths }}
@@ -24,28 +24,36 @@ spec:
           {{- end }}
           - path: {{ .Values.ingress.path }}
             pathType: {{ .Values.ingress.pathType }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
+            backend:
+              service:
+                name: {{ include "sequin.fullname" . }}
+                port:
+                  name: http
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
-    - host: {{ include "common.tplvalues.render" ( dict "value" .name "context" $ ) }}
+    - host: {{ include "sequin.tplrender" ( dict "value" .name "context" $ ) }}
       http:
         paths:
           - path: {{ default "/" .path }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
+            backend:
+              service:
+                name: {{ include "sequin.fullname" $ }}
+                port:
+                  name: http
     {{- end }}
     {{- if .Values.ingress.extraRules }}
-    {{- include "common.tplvalues.render" (dict "value" .Values.ingress.extraRules "context" $) | nindent 4 }}
+    {{- include "sequin.tplrender" (dict "value" .Values.ingress.extraRules "context" $) | nindent 4 }}
     {{- end }}
-  {{- if or (and .Values.ingress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.ingress.annotations )) .Values.ingress.selfSigned)) .Values.ingress.extraTls }}
+  {{- if or (and .Values.ingress.tls (or (hasKey (.Values.ingress.annotations | default dict) "cert-manager.io/cluster-issuer") (hasKey (.Values.ingress.annotations | default dict) "cert-manager.io/issuer") .Values.ingress.selfSigned)) .Values.ingress.extraTls }}
   tls:
-    {{- if and .Values.ingress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.ingress.annotations )) .Values.ingress.selfSigned) }}
+    {{- if and .Values.ingress.tls (or (hasKey (.Values.ingress.annotations | default dict) "cert-manager.io/cluster-issuer") (hasKey (.Values.ingress.annotations | default dict) "cert-manager.io/issuer") .Values.ingress.selfSigned) }}
     - hosts:
         - {{ .Values.ingress.hostname | quote }}
       secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
     {{- end }}
     {{- if .Values.ingress.extraTls }}
-    {{- include "common.tplvalues.render" (dict "value" .Values.ingress.extraTls "context" $) | nindent 4 }}
+    {{- include "sequin.tplrender" (dict "value" .Values.ingress.extraTls "context" $) | nindent 4 }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/sequin/templates/metrics-svc.yaml
+++ b/charts/sequin/templates/metrics-svc.yaml
@@ -2,13 +2,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ printf "%s-metrics" (include "common.names.fullname" .) }}
-  namespace: {{ include "common.names.namespace" . | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  name: {{ printf "%s-metrics" (include "sequin.fullname" .) }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "sequin.labels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: metrics
   {{- if or .Values.metrics.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.service.annotations .Values.commonAnnotations ) "context" . ) }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+  {{- $annotations := include "sequin.mergeValues" ( dict "values" ( list .Values.metrics.service.annotations .Values.commonAnnotations ) "context" . ) }}
+  annotations: {{- include "sequin.tplrender" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
   type: {{ .Values.metrics.service.type }}
@@ -33,7 +33,7 @@ spec:
       protocol: TCP
       targetPort: metrics
     {{- if .Values.metrics.service.extraPorts }}
-    {{- include "common.tplvalues.render" (dict "value" .Values.metrics.service.extraPorts "context" $) | nindent 4 }}
+    {{- include "sequin.tplrender" (dict "value" .Values.metrics.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  selector: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  selector: {{- include "sequin.selectorLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
 {{- end }}

--- a/charts/sequin/templates/podmonitor.yaml
+++ b/charts/sequin/templates/podmonitor.yaml
@@ -2,14 +2,14 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: {{ template "common.names.fullname" . }}
-  namespace: {{ default (include "common.names.namespace" .) .Values.metrics.podMonitor.namespace | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  name: {{ template "sequin.fullname" . }}
+  namespace: {{ default .Release.Namespace .Values.metrics.podMonitor.namespace | quote }}
+  labels: {{- include "sequin.labels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- if .Values.metrics.podMonitor.additionalLabels }}
-    {{- include "common.tplvalues.render" (dict "value" .Values.metrics.podMonitor.additionalLabels "context" $) | nindent 4 }}
+    {{- include "sequin.tplrender" (dict "value" .Values.metrics.podMonitor.additionalLabels "context" $) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "sequin.tplrender" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
   podMetricsEndpoints:
@@ -70,7 +70,7 @@ spec:
   {{- end }}
   namespaceSelector:
     matchNames:
-      - {{ include "common.names.namespace" . | quote }}
+      - {{ .Release.Namespace | quote }}
   selector:
-    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 6 }}
+    matchLabels: {{- include "sequin.selectorLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 6 }}
 {{- end }}

--- a/charts/sequin/templates/prometheusrule.yaml
+++ b/charts/sequin/templates/prometheusrule.yaml
@@ -2,17 +2,17 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: {{ template "common.names.fullname" . }}
-  namespace: {{ default (include "common.names.namespace" .) .Values.metrics.prometheusRule.namespace | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  name: {{ template "sequin.fullname" . }}
+  namespace: {{ default .Release.Namespace .Values.metrics.prometheusRule.namespace | quote }}
+  labels: {{- include "sequin.labels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- if .Values.metrics.prometheusRule.additionalLabels }}
-    {{- include "common.tplvalues.render" (dict "value" .Values.metrics.prometheusRule.additionalLabels "context" $) | nindent 4 }}
+    {{- include "sequin.tplrender" (dict "value" .Values.metrics.prometheusRule.additionalLabels "context" $) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "sequin.tplrender" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
   groups:
-    - name: {{ include "common.names.fullname" . }}
-      rules: {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.prometheusRule.rules "context" $ ) | nindent 8 }}
+    - name: {{ include "sequin.fullname" . }}
+      rules: {{- include "sequin.tplrender" ( dict "value" .Values.metrics.prometheusRule.rules "context" $ ) | nindent 8 }}
 {{- end }}

--- a/charts/sequin/templates/secret-external-db.yaml
+++ b/charts/sequin/templates/secret-external-db.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-externaldb" (include "common.names.fullname" .) }}
-  namespace: {{ include "common.names.namespace" . | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  name: {{ printf "%s-externaldb" (include "sequin.fullname" .) }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "sequin.labels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "sequin.tplrender" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 type: Opaque
 data:

--- a/charts/sequin/templates/secret-external-redis.yaml
+++ b/charts/sequin/templates/secret-external-redis.yaml
@@ -6,10 +6,10 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "sequin.redis.secretName" . }}
-  namespace: {{ include "common.names.namespace" . | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "sequin.labels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+  annotations: {{- include "sequin.tplrender" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
   {{- end }}
 type: Opaque
 data:

--- a/charts/sequin/templates/secrets.yaml
+++ b/charts/sequin/templates/secrets.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "common.names.fullname" . }}
-  namespace: {{ include "common.names.namespace" . | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  name: {{ include "sequin.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "sequin.labels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "sequin.tplrender" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 type: Opaque
 data:

--- a/charts/sequin/templates/service-account.yaml
+++ b/charts/sequin/templates/service-account.yaml
@@ -3,11 +3,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "sequin.serviceAccountName" . }}
-  namespace: {{ include "common.names.namespace" . | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "sequin.labels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if or .Values.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+  {{- $annotations := include "sequin.mergeValues" ( dict "values" ( list .Values.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
+  annotations: {{- include "sequin.tplrender" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/charts/sequin/templates/service-monitor.yaml
+++ b/charts/sequin/templates/service-monitor.yaml
@@ -2,14 +2,14 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ template "common.names.fullname" . }}
-  namespace: {{ default (include "common.names.namespace" .) .Values.metrics.serviceMonitor.namespace | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  name: {{ template "sequin.fullname" . }}
+  namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace | quote }}
+  labels: {{- include "sequin.labels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- if .Values.metrics.serviceMonitor.additionalLabels }}
-    {{- include "common.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.additionalLabels "context" $) | nindent 4 }}
+    {{- include "sequin.tplrender" (dict "value" .Values.metrics.serviceMonitor.additionalLabels "context" $) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "sequin.tplrender" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
   endpoints:
@@ -70,8 +70,8 @@ spec:
   {{- end }}
   namespaceSelector:
     matchNames:
-      - {{ include "common.names.namespace" . | quote }}
+      - {{ .Release.Namespace | quote }}
   selector:
-    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 6 }}
+    matchLabels: {{- include "sequin.selectorLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: metrics
 {{- end }}

--- a/charts/sequin/templates/service.yaml
+++ b/charts/sequin/templates/service.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "common.names.fullname" . }}
-  namespace: {{ include "common.names.namespace" . | quote }}
-  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.service.labels .Values.commonLabels ) "context" . ) }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
+  name: {{ template "sequin.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  {{- $labels := include "sequin.mergeValues" ( dict "values" ( list .Values.service.labels .Values.commonLabels ) "context" . ) }}
+  labels: {{- include "sequin.labels" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
   {{- if or .Values.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.service.annotations .Values.commonAnnotations ) "context" . ) }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+  {{- $annotations := include "sequin.mergeValues" ( dict "values" ( list .Values.service.annotations .Values.commonAnnotations ) "context" . ) }}
+  annotations: {{- include "sequin.tplrender" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
@@ -27,7 +27,7 @@ spec:
   sessionAffinity: {{ .Values.service.sessionAffinity }}
   {{- end }}
   {{- if .Values.service.sessionAffinityConfig }}
-  sessionAffinityConfig: {{- include "common.tplvalues.render" (dict "value" .Values.service.sessionAffinityConfig "context" $) | nindent 4 }}
+  sessionAffinityConfig: {{- include "sequin.tplrender" (dict "value" .Values.service.sessionAffinityConfig "context" $) | nindent 4 }}
   {{- end }}
   ports:
     - name: http
@@ -40,7 +40,7 @@ spec:
       nodePort: null
       {{- end }}
     {{- if .Values.service.extraPorts }}
-    {{- include "common.tplvalues.render" (dict "value" .Values.service.extraPorts "context" $) | nindent 4 }}
+    {{- include "sequin.tplrender" (dict "value" .Values.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
-  selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
+  {{- $podLabels := include "sequin.mergeValues" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
+  selector: {{- include "sequin.selectorLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}

--- a/charts/sequin/templates/tls-secret.yaml
+++ b/charts/sequin/templates/tls-secret.yaml
@@ -5,10 +5,10 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .name }}
-  namespace: {{ include "common.names.namespace" $ | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" $.Values.commonLabels "context" $ ) | nindent 4 }}
+  namespace: {{ $.Release.Namespace | quote }}
+  labels: {{- include "sequin.labels" ( dict "customLabels" $.Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if $.Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" $.Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "sequin.tplrender" ( dict "value" $.Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 type: kubernetes.io/tls
 data:
@@ -21,19 +21,20 @@ data:
 {{- $secretName := printf "%s-tls" .Values.ingress.hostname }}
 {{- $ca := genCA "sequin-ca" 365 }}
 {{- $cert := genSignedCert .Values.ingress.hostname nil (list .Values.ingress.hostname) 365 $ca }}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $secretName }}
-  namespace: {{ include "common.names.namespace" . | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "sequin.labels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "sequin.tplrender" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 type: kubernetes.io/tls
 data:
-  tls.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.crt" "defaultValue" $cert.Cert "context" $) }}
-  tls.key: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.key" "defaultValue" $cert.Key "context" $) }}
-  ca.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" $ca.Cert "context" $) }}
+  tls.crt: {{ if and $existing (index $existing.data "tls.crt") }}{{ index $existing.data "tls.crt" }}{{ else }}{{ $cert.Cert | b64enc }}{{ end }}
+  tls.key: {{ if and $existing (index $existing.data "tls.key") }}{{ index $existing.data "tls.key" }}{{ else }}{{ $cert.Key | b64enc }}{{ end }}
+  ca.crt: {{ if and $existing (index $existing.data "ca.crt") }}{{ index $existing.data "ca.crt" }}{{ else }}{{ $ca.Cert | b64enc }}{{ end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## Summary

Removes the `bitnami/common` Helm library chart as a dependency from the
Sequin chart. All 129 call sites previously delegating to `common.*`
helpers have been replaced with equivalent local helpers defined in
`templates/_helpers.tpl`. Chart version is bumped to `0.3.0`.

Closes INFRAVPIA-127 / part of INFRAVPIA-14.

## Motivation

`bitnami/common` is a transitive dependency that couples our chart to
Bitnami's release cadence and adds ~500 KB of unused template logic. It
was the last Bitnami artifact in the Sequin chart after the
Redis → Valkey migration (INFRAVPIA-114).

## Changes

- **`Chart.yaml`**: removed `bitnami/common` from `dependencies`,
  version `0.2.2 → 0.3.0`
- **`Chart.lock`**: regenerated — now references only
  `cloudpirates/valkey:0.17.0`
- **`templates/_helpers.tpl`**: 9 existing helpers rewritten + 13 new
  local helpers added to cover every `common.*` call:
  - `sequin.labels`, `sequin.selectorLabels`, `sequin.matchLabels`
  - `sequin.serviceAccountName`, `sequin.imagePullSecrets`
  - `sequin.image`, `sequin.tplvalues.render`, `sequin.tplvalues.merge`
  - `sequin.affinities.pods` (soft/hard/`""`), `sequin.topologySpreadConstraints`
  - `sequin.resources.preset` (hardcoded tables from `bitnami/common:2.40.0`)
  - `sequin.waitForJob`, `sequin.job.createAfterHook`
- **All 14 template files**: updated to use local helpers

## Implementation notes

- `sequin.resources.preset` is kept (not removed) because `sequin.tf`
  relies on the `"small"` preset silently — no explicit resource block is
  set for the Sequin container. Dropping it would have removed resource
  limits from production without any visible config change.
  `small` maps to `requests: cpu=500m memory=512Mi` /
  `limits: cpu=750m memory=768Mi`.
- `sequin.labels` / `sequin.selectorLabels` use `fromYaml | pick | merge`
  (not string concatenation) to match bitnami's real merge semantics:
  custom labels take priority over standard labels, but only
  `app.kubernetes.io/name` and `app.kubernetes.io/instance` from custom
  labels are allowed in `matchLabels` (immutable field).
- `sequin.affinities.pods` requires trim on both sides of the type
  comparison to avoid a stray blank line in rendered output.
- `sequin.tplvalues.merge` mirrors bitnami's real implementation
  (`fromYaml | merge $dst` per item, first item wins).

## Testing

- `helm lint --strict`: clean, zero warnings
- `helm dependency update`: only `valkey-0.17.0.tgz` in `charts/`
- `helm template` diff vs pre-migration baseline: only
  `helm.sh/chart: sequin-0.2.2 → sequin-0.3.0` (expected)
- Resource count: 9 objects before and after (ServiceAccount, 2×Secret,
  ConfigMap, 3×Service, Deployment, StatefulSet)